### PR TITLE
Reproducible Builds 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Build Collator Node
 
 on:
   push:
@@ -19,12 +19,10 @@ jobs:
         uses: ConorMacBride/install-package@v1.1.0
         with:
           apt: protobuf-compiler
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check Cargo version
         run: cargo --version --verbose
-      - name: Update Rust
-        run: rustup update ; rustup update nightly ; rustup target add wasm32-unknown-unknown --toolchain nightly
-      - name: Check Rust version
-        run: rustup show
+      - name: Check Rust Toolchain
+        run: rustup show --verbose
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --verbose --locked

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -1,0 +1,43 @@
+name: Build Collator Node and Release WebAssembly
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  SUBWASM_VERSION: 0.19.0
+  WASM_PATH: target/release/wbuild/logion-runtime/logion_runtime.compact.compressed.wasm
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install required packages
+        uses: ConorMacBride/install-package@v1.1.0
+        with:
+          apt: protobuf-compiler jq
+      - name: Install subwasm
+        run: |
+          wget https://github.com/chevdor/subwasm/releases/download/v${{ env.SUBWASM_VERSION }}/subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+          sudo apt install -y ./subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+          subwasm --version
+      - uses: actions/checkout@v3
+      - name: Check Cargo version
+        run: cargo --version --verbose
+      - name: Check Rust Toolchain
+        run: rustup show --verbose
+      - name: Build
+        run: cargo build --release --verbose --locked
+      - name: Set specVersion
+        run: |
+          SPEC_VERSION=$(subwasm --json version ${{ env.WASM_PATH }} | jq .specVersion)
+          echo "specVersion: $SPEC_VERSION"
+          mv ${{ env.WASM_PATH }} "logion_runtime-$SPEC_VERSION.compact.compressed.wasm"
+      - name: Saves artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: logion_runtime
+          path: logion_runtime-*.compact.compressed.wasm
+          retention-days: 15

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly-2023-01-10"
+components = ["rustfmt"]
+targets = ["wasm32-unknown-unknown"]
+profile = "minimal"


### PR DESCRIPTION
- Toolchain is now configured at project level.
- A manually-triggered Github action is now available to store compact/compressed runtime as an artefact.